### PR TITLE
Preserve ERT backtrace

### DIFF
--- a/el-mock.el
+++ b/el-mock.el
@@ -149,17 +149,16 @@ When you adapt Emacs Lisp Mock to a testing framework, wrap test method around t
         -stubbed-functions
         -mocked-functions
         (in-mocking t)
-        any-error)
+        (any-error t))
     ;; (setplist 'mock-original-func nil)
     ;; (setplist 'mock-call-count nil)
     (unwind-protect
-        (condition-case e
+        (prog1
             (funcall body-fn)
-          (error (setq any-error e)))
+          (setq any-error nil))
       (mapc #'stub/teardown -stubbed-functions)
       (unwind-protect
-          (if any-error
-              (signal (car any-error) (cdr any-error))
+          (unless any-error
             (mock-verify))
         (mapc #'mock/teardown -mocked-functions)))))
 

--- a/test/el-mock-test.el
+++ b/test/el-mock-test.el
@@ -364,3 +364,20 @@
      (mock (foo 1))
      (foo)))
  )
+
+(defun el-mock-test--signal ()
+  (error "Foo"))
+
+
+(ert-deftest preserve-stacktrace ()
+  "Test that mocking doesn’t mess with the backtrace recorded by
+‘ert-run-test’."
+  (let ((result (ert-run-test
+                 (make-ert-test
+                  :body (lambda ()
+                          (with-mock (el-mock-test--signal)))))))
+    (should (ert-test-failed-p result))
+    (should (equal (ert-test-failed-condition result)
+                   '(error "Foo")))
+    (should (equal (car-safe (ert-test-failed-backtrace result))
+                   '(t el-mock-test--signal)))))


### PR DESCRIPTION
Remove use of ‘condition-case’.  This construct throws away the
backtrace, making debugging failing tests much harder.  Use the existing
‘unwind-protect’ instead.