### PR TITLE
Fix missing incf function symbol to cl-incf

### DIFF
--- a/el-mock.el
+++ b/el-mock.el
@@ -94,7 +94,7 @@
        (put funcsym 'mock-call-count 0)
        (fset funcsym
                      `(lambda (&rest actual-args)
-                        (incf (get ',funcsym 'mock-call-count))
+                        (cl-incf (get ',funcsym 'mock-call-count))
                         (add-to-list 'mock-verify-list
                                      (list ',funcsym ',(cdr func-spec) actual-args ,times))
                         ,value))))))


### PR DESCRIPTION
Using directly the cl-incf symbol from the already required cl-lib
library seems more appropriate than requiring the 'cl library (which
aliases that incf symbol with cl-incf).

Related #18