### PR TITLE
CI coverage for Emacs 28.1; fix 80 character width warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        emacs_version: ['24.4', '24.5', '25.1', '25.2', '25.3', '26.1', '27.1', 'snapshot']
+        emacs_version: ['24.4', '24.5', '25.1', '25.2', '25.3', '26.1', '27.1', '28.1', 'snapshot']
         cask_version: ['snapshot']
 
     steps:

--- a/el-mock.el
+++ b/el-mock.el
@@ -144,7 +144,8 @@
 Prepare for mock/stub, call BODY-FN, and teardown mock/stub.
 
 For developer:
-When you adapt Emacs Lisp Mock to a testing framework, wrap test method around this function."
+When you adapt Emacs Lisp Mock to a testing framework,
+wrap test method around this function."
   (let (mock-verify-list
         -stubbed-functions
         -mocked-functions
@@ -186,7 +187,8 @@ Example:
 
 (defmacro stub (function &rest rest)
   "Create a stub for FUNCTION.
-Stubs are temporary functions which accept any arguments and return constant value.
+Stubs are temporary functions which accept any arguments
+and return constant value.
 Stubs are removed outside `with-mock' (`with-stub' is an alias) and `mocklet'.
 
 Synopsis:
@@ -214,8 +216,10 @@ Example:
 
 (defmacro mock (func-spec &rest rest)
     "Create a mock for function described by FUNC-SPEC.
-Mocks are temporary functions which accept specified arguments and return constant value.
-If mocked functions are not called or called by different arguments, an `mock-error' occurs.
+Mocks are temporary functions which accept specified arguments
+and return constant value.
+If mocked functions are not called or called by different arguments,
+an `mock-error' occurs.
 Mocks are removed outside `with-mock' and `mocklet'.
 
 Synopsis:


### PR DESCRIPTION
This also fixes an 80 character width warning, seen here: https://github.com/emacs-lsp/lsp-mode/runs/6973887788?check_suite_focus=true#step:6:157