### PR TITLE
Update preserve-stacktrace test for Emacs with native compilation

### DIFF
--- a/test/el-mock-test.el
+++ b/test/el-mock-test.el
@@ -415,8 +415,17 @@
       (should (equal
                (nth 2 (ert-test-failed-backtrace result))
                '(t el-mock-test--signal nil nil))))
-     (t
+     ((not (native-comp-available-p))
       (should (equal
                (nth 2 (ert-test-failed-backtrace result))
                (record 'backtrace-frame t 'el-mock-test--signal
+                       nil nil nil nil nil))))
+     (t
+      (should (equal
+               (nth 2 (ert-test-failed-backtrace result))
+               (record 'backtrace-frame t
+                       (list 'closure
+                           (list 'el-mock-test-var t)
+                           nil
+                         (list 'el-mock-test--signal))
                        nil nil nil nil nil)))))))


### PR DESCRIPTION
* The backtrace-frame format seems to have changed when Emacs is built with native compilation.
* This updates the test with the new format.
  - Tested with Emacs 28.2 and 29.4.